### PR TITLE
Detecting bayesian decoded sequences

### DIFF
--- a/projects/emily_shortcut/decode.ipynb
+++ b/projects/emily_shortcut/decode.ipynb
@@ -32,10 +32,10 @@
    },
    "outputs": [],
    "source": [
-    "# pickle_filepath = 'E:\\\\code\\\\python-vdmlab\\\\projects\\\\emily_shortcut\\\\cache\\\\pickled\\\\'\n",
-    "# output_filepath = 'E:\\\\code\\\\python-vdmlab\\\\projects\\\\emily_shortcut\\\\plots\\\\sequence\\\\'\n",
-    "pickle_filepath = 'C:\\\\Users\\\\Emily\\\\Code\\\\python-vdmlab\\\\projects\\\\emily_shortcut\\\\cache\\\\pickled\\\\'\n",
-    "output_filepath = 'C:\\\\Users\\\\Emily\\\\Code\\\\python-vdmlab\\\\projects\\\\emily_shortcut\\\\plots\\\\sequence\\\\'"
+    "pickle_filepath = 'E:\\\\code\\\\python-vdmlab\\\\projects\\\\emily_shortcut\\\\cache\\\\pickled\\\\'\n",
+    "output_filepath = 'E:\\\\code\\\\python-vdmlab\\\\projects\\\\emily_shortcut\\\\plots\\\\sequence\\\\'\n",
+    "# pickle_filepath = 'C:\\\\Users\\\\Emily\\\\Code\\\\python-vdmlab\\\\projects\\\\emily_shortcut\\\\cache\\\\pickled\\\\'\n",
+    "# output_filepath = 'C:\\\\Users\\\\Emily\\\\Code\\\\python-vdmlab\\\\projects\\\\emily_shortcut\\\\plots\\\\sequence\\\\'"
    ]
   },
   {
@@ -60,8 +60,8 @@
     "print(info.session_id)\n",
     "pos = info.get_pos(info.pxl_to_cm)\n",
     "\n",
-    "t_start = info.task_times['phase3'][0]\n",
-    "t_stop = info.task_times['phase3'][1]\n",
+    "t_start = info.task_times['phase2'][0]\n",
+    "t_stop = info.task_times['phase2'][1]\n",
     "\n",
     "t_start_idx = vdm.find_nearest_idx(pos['time'], t_start)\n",
     "t_end_idx = vdm.find_nearest_idx(pos['time'], t_stop)\n",
@@ -77,11 +77,218 @@
     "\n",
     "tc = get_tc(info, sliced_pos, pickle_filepath)\n",
     "\n",
-    "sort_idx = vdm.get_sort_idx(tc['u'])\n",
-    "odd_firing_idx = get_odd_firing_idx(tc['u'])\n",
+    "# sort_idx = vdm.get_sort_idx(tc['u'])\n",
+    "# odd_firing_idx = get_odd_firing_idx(tc['u'])\n",
     "\n",
-    "ordered_spikes = spikes['time'][sort_idx]"
+    "# ordered_spikes = spikes['time'][sort_idx]"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "linear = linear['u']\n",
+    "tc = np.array(tc['u'])\n",
+    "\n",
+    "dt = np.median(np.diff(linear['time']))\n",
+    "edges = np.hstack((linear['time']-(dt/2), linear['time'][-1]))\n",
+    "subsample = 6\n",
+    "edges = edges[::subsample]\n",
+    "counts = vdm.get_counts(spikes['time'], edges)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "plt.pcolormesh(counts[:,:100])\n",
+    "plt.colorbar()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "centers = edges[:-1] + np.median(np.diff(edges))/2\n",
+    "prob = vdm.bayesian_prob(counts, tc, centers)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "plt.pcolormesh(prob[200::-1])\n",
+    "plt.colorbar()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "decoded_position = vdm.decode_location(prob, linear)\n",
+    "\n",
+    "decoded = dict()\n",
+    "decoded['time'] = centers\n",
+    "decoded['position'] = decoded_position\n",
+    "\n",
+    "actual_idx = vdm.find_nearest_indices(linear['time'], decoded['time'])\n",
+    "actual_location = linear['position'][actual_idx]\n",
+    "\n",
+    "# decoded['position'][np.isnan(decoded['position'])] = 0\n",
+    "decode_error = np.abs(actual_location - decoded['position'])\n",
+    "print(np.mean(decode_error))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "plt.plot(decoded['time'], decoded['position'], 'b.')\n",
+    "plt.plot(linear['time'], linear['position'], 'r.')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def find_jumps(decoded, min_idx_length=3, max_idx_jump=20):\n",
+    "    \"\"\"Finds intervals of decoded position that are within jump limits.\n",
+    "    \n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    decoded : np.array\n",
+    "        Estimate of decoded location (floats) for each time bin.\n",
+    "    min_idx_length : int\n",
+    "        Minimum number of bins to be considered a sequence.\n",
+    "    max_idx_jump : int\n",
+    "        Maximum number of bins to break a sequence.\n",
+    "    \n",
+    "    Returns\n",
+    "    -------\n",
+    "    sequences : dict\n",
+    "        With time (tuple of floats), index (tuple of ints) as keys.\n",
+    "        Where start, stop are [0], [1] of each tuple.\n",
+    "    \n",
+    "    \"\"\"\n",
+    "    previous_position = -100\n",
+    "    start_idx = []\n",
+    "    sequences = dict(time=[], index=[])\n",
+    "\n",
+    "    for idx, position in enumerate(decoded['position']):\n",
+    "        this_jump = np.abs(position - previous_position)\n",
+    "        if this_jump <= max_idx_jump:\n",
+    "            if len(start_idx) < 1:\n",
+    "                start_idx.append(idx-1)\n",
+    "            else:\n",
+    "                if ((idx-1) - start_idx[0]) >= min_idx_length:\n",
+    "                    sequences['time'].append((decoded['time'][start_idx[0]], decoded['time'][idx-1]))\n",
+    "                    sequences['index'].append((start_idx[0], idx-1))\n",
+    "                    start_idx = []\n",
+    "        previous_position = position\n",
+    "    \n",
+    "    return sequences\n",
+    "        "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(sequences['time'][:10], sequences['index'][:10])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "plt.plot(linear['time'], linear['position'], 'r.')\n",
+    "for seq in sequences['index']:\n",
+    "    plt.plot(decoded['time'][seq[0]:seq[1]], decoded['position'][seq[0]:seq[1]], 'b.')\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "avg_error = []\n",
+    "decoded['position'][np.isnan(decoded['position'])] = 0\n",
+    "for seq in sequences['index']:\n",
+    "    decode_error = np.abs(actual_location[seq[0]:seq[1]] - decoded['position'][seq[0]:seq[1]])\n",
+    "    avg_error.append(np.mean(decode_error))\n",
+    "print(np.mean(avg_error))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",
@@ -408,6 +615,27 @@
    "outputs": [],
    "source": [
     "def get_counts(spikes, edges, gaussian_std=0.02, gaussian_window=1.0):\n",
+    "    \"\"\"Finds the number of spikes in each bin.\n",
+    "    \n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    spikes : np.array\n",
+    "        Where each inner array contains the spike times (floats) for an individual neuron.\n",
+    "    edges : np.array\n",
+    "        Bin edges for computing spike counts.\n",
+    "    gaussian_std : float\n",
+    "        Standard deviation for gaussian filter. Default set to 0.02. Normalized by bin size (dt).\n",
+    "        Only uses filter if this value is greater than dt.\n",
+    "    gaussian_window : float\n",
+    "        Window for gaussian filter. Default set to 1.0. Normalized by bin size (dt).\n",
+    "        Only uses filter if gaussian_std is greater than dt.\n",
+    "    \n",
+    "    Returns\n",
+    "    -------\n",
+    "    counts : np.array\n",
+    "        Where each inner array is the number of spikes (int) in each bin for an individual neuron. \n",
+    "    \n",
+    "    \"\"\"\n",
     "    dt = np.median(np.diff(edges))\n",
     "    \n",
     "    apply_filter = False\n",
@@ -425,7 +653,7 @@
     "    for idx, neuron_spikes in enumerate(spikes):\n",
     "        counts[idx] = np.histogram(neuron_spikes, bins=edges)[0]\n",
     "        if apply_filter:\n",
-    "            counts[idx] = np.convolve(q[idx], gaussian_filter, mode='same')\n",
+    "            counts[idx] = np.convolve(counts[idx], gaussian_filter, mode='same')\n",
     "    return counts"
    ]
   },
@@ -476,6 +704,32 @@
    "outputs": [],
    "source": [
     "def bayesian_prob(counts, tuning_curves, centers, min_neurons=1, min_spikes=1):\n",
+    "    \"\"\"Computes the bayesian probability of location based on spike counts.\n",
+    "    \n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    counts : np.array\n",
+    "        Where each inner array is the number of spikes (int) in each bin for an individual neuron. \n",
+    "    tuning_curves : np.array\n",
+    "        Where each inner array is the tuning curve (floats) for an individual neuron. \n",
+    "    centers : np.array\n",
+    "        Bin centers from computing spike counts, based on edges given to get_counts().\n",
+    "    min_neurons : int\n",
+    "        Mininum number of neurons active in a given bin. Default is 1.\n",
+    "    min_spikes : int\n",
+    "        Mininum number of spikes in a given bin. Default is 1.\n",
+    "    \n",
+    "    Returns\n",
+    "    -------\n",
+    "    prob : np.array\n",
+    "        Where each inner array is the probability (floats) for an individual neuron by location bins. \n",
+    "    \n",
+    "    Notes\n",
+    "    -----\n",
+    "    If a bin does not meet the min_neuron/min_spikes requirement, that bin's probability \n",
+    "    is set to nan. To convert it to 0s instead, use : prob[np.isnan(prob)] = 0 on the output.\n",
+    "    \n",
+    "    \"\"\"\n",
     "    length = np.shape(counts)[1]\n",
     "    num_bins = np.shape(tuning_curves)[1]\n",
     "    bin_size = np.median(np.diff(centers))\n",
@@ -492,7 +746,6 @@
     "\n",
     "\n",
     "    prob /= np.sum(prob, axis=1)[..., np.newaxis]\n",
-    "    # prob[np.isnan(prob)] = 0 add to docstring\n",
     "    \n",
     "    num_active_neurons = np.sum(counts > min_spikes, axis=0)\n",
     "    prob[num_active_neurons < min_neurons] = np.nan\n",
@@ -524,6 +777,21 @@
    "outputs": [],
    "source": [
     "def decode_location(prob, linear):\n",
+    "    \"\"\"Finds the decoded location based on a linear (1D) trajectory.\n",
+    "    \n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    prob : np.array\n",
+    "        Where each inner array is the probability (floats) for an individual neuron by location bins.\n",
+    "    linear : dict\n",
+    "        With position (floats), time (floats) as keys.\n",
+    "    \n",
+    "    Returns\n",
+    "    -------\n",
+    "    decoded : np.array\n",
+    "        Estimate of decoded location (floats) for each time bin.\n",
+    "    \n",
+    "    \"\"\"\n",
     "    max_decoded_idx = np.argmax(prob, axis=1)\n",
     "    decoded = max_decoded_idx * (np.max(linear['position'])-np.min(linear['position'])) / (np.shape(prob)[1]-1)\n",
     "    decoded += np.min(linear['position'])\n",
@@ -543,6 +811,24 @@
    "outputs": [],
    "source": [
     "def find_nearest_indices(array, vals):\n",
+    "    \"\"\"Finds nearest index in array to value.\n",
+    "    \n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    array : np.array\n",
+    "        This is the array you wish to index into.\n",
+    "    vals : np.array\n",
+    "        This is the array that you are getting your indices from.\n",
+    "    \n",
+    "    Returns\n",
+    "    -------\n",
+    "    Indices into array that is closest to vals.\n",
+    "    \n",
+    "    Notes\n",
+    "    -----\n",
+    "    Wrapper around find_nearest_idx().\n",
+    "    \n",
+    "    \"\"\"\n",
     "    return np.array([vdm.find_nearest_idx(array, val) for val in vals], dtype=int)"
    ]
   },
@@ -562,6 +848,17 @@
     "decoded[np.isnan(decoded)] = 0\n",
     "decode_error = np.abs(actual_location - decoded)\n",
     "np.mean(decode_error)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(decoded)"
    ]
   },
   {

--- a/projects/emily_shortcut/shortcut_decode.py
+++ b/projects/emily_shortcut/shortcut_decode.py
@@ -1,9 +1,9 @@
 import os
+import numpy as np
 import matplotlib.pyplot as plt
 import vdmlab as vdm
 
 from tuning_curves_functions import get_tc, linearize
-from plotting_functions import plot_sorted_tc
 
 import info.R063d2_info as r063d2
 import info.R063d3_info as r063d3
@@ -12,44 +12,88 @@ import info.R063d5_info as r063d5
 import info.R063d6_info as r063d6
 import info.R066d1_info as r066d1
 import info.R066d2_info as r066d2
+# import info.R066d3_info as r066d3
 import info.R066d4_info as r066d4
 
 
 thisdir = os.path.dirname(os.path.realpath(__file__))
 
-
-info = r066d4
-# infos = [r063d2, r063d3, r063d4, r063d5, r063d6, r066d1, r066d2, r066d4]
-
 pickle_filepath = os.path.join(thisdir, 'cache', 'pickled')
 output_filepath = os.path.join(thisdir, 'plots', 'decode')
 
-print(info.session_id)
-pos = info.get_pos(info.pxl_to_cm)
 
-t_start = info.task_times['phase3'][0]
-t_stop = info.task_times['phase3'][1]
+# infos = [r063d3]
+infos = [r063d2, r063d3, r063d4, r063d5, r063d6, r066d1, r066d2, r066d4]
 
-t_start_idx = vdm.find_nearest_idx(pos['time'], t_start)
-t_end_idx = vdm.find_nearest_idx(pos['time'], t_stop)
 
-sliced_pos = dict()
-sliced_pos['x'] = pos['x'][t_start_idx:t_end_idx]
-sliced_pos['y'] = pos['y'][t_start_idx:t_end_idx]
-sliced_pos['time'] = pos['time'][t_start_idx:t_end_idx]
+for info in infos:
+    print(info.session_id)
+    pos = info.get_pos(info.pxl_to_cm)
 
-linear, zone = linearize(info, pos)
+    t_start = info.task_times['phase2'][0]
+    t_stop = info.task_times['phase2'][1]
 
-spikes = info.get_spikes()
+    t_start_idx = vdm.find_nearest_idx(pos['time'], t_start)
+    t_end_idx = vdm.find_nearest_idx(pos['time'], t_stop)
 
-tc = get_tc(info, sliced_pos, pickle_filepath)
+    sliced_pos = dict()
+    sliced_pos['x'] = pos['x'][t_start_idx:t_end_idx]
+    sliced_pos['y'] = pos['y'][t_start_idx:t_end_idx]
+    sliced_pos['time'] = pos['time'][t_start_idx:t_end_idx]
 
-# sort_idx = vdm.get_sort_idx(tc['u'])
-# ordered_spikes = spikes['time'][sort_idx]
+    linear, zone = linearize(info, pos)
 
-for thisposition in linear['u']['time'][1000:10500]:
-    x = vdm.find_nearest_idx(pos['time'], thisposition)
-    # plt.plot(pos['time'][x], pos['x'][x], 'b.')
-    # plt.plot(pos['time'][x], pos['y'][x], 'g.')
-    plt.plot(pos['x'][x], pos['y'][x], 'r.')
-    plt.show()
+    spikes = info.get_spikes()
+
+    tc = get_tc(info, sliced_pos, pickle_filepath)
+
+    linear = linear['u']
+    tc = np.array(tc['u'])
+
+    dt = np.median(np.diff(linear['time']))
+    edges = np.hstack((linear['time']-(dt/2), linear['time'][-1]))
+    subsample = 6
+    edges = edges[::subsample]
+    counts = vdm.get_counts(spikes['time'], edges)
+
+    # plt.pcolormesh(counts[:,:100])
+    # plt.colorbar()
+    # plt.show()
+
+    centers = edges[:-1] + np.median(np.diff(edges))/2
+    prob = vdm.bayesian_prob(counts, tc, centers)
+
+    # plt.pcolormesh(prob[200::-1])
+    # plt.colorbar()
+    # plt.show()
+
+    decoded_position = vdm.decode_location(prob, linear)
+
+    decoded = dict()
+    decoded['time'] = centers
+    decoded['position'] = decoded_position
+
+    actual_idx = vdm.find_nearest_indices(linear['time'], centers)
+    actual_location = linear['position'][actual_idx]
+
+    # decoded[np.isnan(decoded)] = 0
+    # decode_error = np.abs(actual_location - decoded)
+    # print(np.mean(decode_error))
+    #
+    # plt.plot(centers, decoded)
+    # plt.plot(linear['time'], linear['position'], 'r.')
+    # plt.show()
+
+    sequences = vdm.decoded_sequences(decoded)
+
+    avg_error = []
+    decoded['position'][np.isnan(decoded['position'])] = 0
+    for seq in sequences['index']:
+        decode_error = np.abs(actual_location[seq[0]:seq[1]] - decoded['position'][seq[0]:seq[1]])
+        avg_error.append(np.mean(decode_error))
+    print(np.mean(avg_error))
+
+    # plt.plot(linear['time'], linear['position'], 'r.')
+    # for seq in sequences['index']:
+    #     plt.plot(decoded['time'][seq[0]:seq[1]], decoded['position'][seq[0]:seq[1]], 'b.')
+    # plt.show()

--- a/vdmlab/__init__.py
+++ b/vdmlab/__init__.py
@@ -1,6 +1,8 @@
-from .utils import find_nearest_idx, time_slice, idx_in_pos, get_sort_idx, add_scalebar
+from .utils import find_nearest_idx, time_slice, idx_in_pos, get_sort_idx, add_scalebar, get_counts, \
+                   find_nearest_indices
 from .maze_breakdown import expand_line, save_spike_position
 from .tuning_curves import linear_trajectory, tuning_curve
 from .place_fields import find_fields, unique_fields, sized_fields, get_single_field, get_heatmaps
 from .lfp_filtering import detect_swr_hilbert
 from .co_occurrence import spike_counts, cooccur_probabilities
+from .decoding import bayesian_prob, decode_location, decoded_sequences

--- a/vdmlab/decoding.py
+++ b/vdmlab/decoding.py
@@ -1,0 +1,113 @@
+import numpy as np
+
+def bayesian_prob(counts, tuning_curves, centers, min_neurons=1, min_spikes=1):
+    """Computes the bayesian probability of location based on spike counts.
+
+    Parameters
+    ----------
+    counts : np.array
+        Where each inner array is the number of spikes (int) in each bin for an individual neuron.
+    tuning_curves : np.array
+        Where each inner array is the tuning curve (floats) for an individual neuron.
+    centers : np.array
+        Bin centers from computing spike counts, based on edges given to get_counts().
+    min_neurons : int
+        Mininum number of neurons active in a given bin. Default is 1.
+    min_spikes : int
+        Mininum number of spikes in a given bin. Default is 1.
+
+    Returns
+    -------
+    prob : np.array
+        Where each inner array is the probability (floats) for an individual neuron by location bins.
+
+    Notes
+    -----
+    If a bin does not meet the min_neuron/min_spikes requirement, that bin's probability
+    is set to nan. To convert it to 0s instead, use : prob[np.isnan(prob)] = 0 on the output.
+
+    """
+    length = np.shape(counts)[1]
+    num_bins = np.shape(tuning_curves)[1]
+    bin_size = np.median(np.diff(centers))
+
+    prob = np.empty((length, num_bins)) * np.nan
+    for idx in range(num_bins):
+        # What does tempprod represent?
+        tempprod = np.nansum(np.log(tuning_curves[:, idx][..., np.newaxis] ** counts), axis=0)
+
+        # What does tempsum represent?
+        tempsum = np.exp(-bin_size * np.nansum(tuning_curves[:, idx]))
+
+        prob[:, idx] = np.exp(tempprod) * tempsum * (1/num_bins)
+
+
+    prob /= np.sum(prob, axis=1)[..., np.newaxis]
+
+    num_active_neurons = np.sum(counts > min_spikes, axis=0)
+    prob[num_active_neurons < min_neurons] = np.nan
+    return prob
+
+
+def decode_location(prob, linear):
+    """Finds the decoded location based on a linear (1D) trajectory.
+
+    Parameters
+    ----------
+    prob : np.array
+        Where each inner array is the probability (floats) for an individual neuron by location bins.
+    linear : dict
+        With position (floats), time (floats) as keys.
+
+    Returns
+    -------
+    decoded : np.array
+        Estimate of decoded location (floats) for each time bin.
+
+    """
+    max_decoded_idx = np.argmax(prob, axis=1)
+    decoded = max_decoded_idx * (np.max(linear['position'])-np.min(linear['position'])) / (np.shape(prob)[1]-1)
+    decoded += np.min(linear['position'])
+
+    nan_idx = np.sum(np.isnan(prob), axis=1) == (np.shape(prob)[1]-1)
+    decoded[nan_idx] = np.nan
+
+    return decoded
+
+
+def decoded_sequences(decoded, min_idx_length=3, max_idx_jump=20):
+    """Finds intervals of decoded position that are within jump limits.
+
+    Parameters
+    ----------
+    decoded : np.array
+        Estimate of decoded location (floats) for each time bin.
+    min_idx_length : int
+        Minimum number of bins to be considered a sequence.
+    max_idx_jump : int
+        Maximum number of bins to break a sequence.
+
+    Returns
+    -------
+    sequences : dict
+        With time (tuple of floats), index (tuple of ints) as keys.
+        Where start, stop are [0], [1] of each tuple.
+
+    """
+    previous_position = -100
+    start_idx = []
+    sequences = dict(time=[], index=[])
+
+    for idx, position in enumerate(decoded['position']):
+        this_jump = np.abs(position - previous_position)
+        if this_jump <= max_idx_jump:
+            if len(start_idx) < 1:
+                start_idx.append(idx-1)
+            else:
+                if ((idx-1) - start_idx[0]) >= min_idx_length:
+                    sequences['time'].append((decoded['time'][start_idx[0]], decoded['time'][idx-1]))
+                    sequences['index'].append((start_idx[0], idx-1))
+                    start_idx = []
+        previous_position = position
+
+    return sequences


### PR DESCRIPTION
**Description:**
Decoding rat position based on spikes using Bayesian decoding 
and a sequence detector that limits a sequence to locations that
are of a certain length and do not "jump" more than a certain
amount.

**How has this been tested?**
Formal tests are not yet set up, but the Bayesian decoding was run 
using the same inputs as the Matlab code for the same function 
(primarily DecodeZ()). The outputs were identical.

**How long should this take to review?**
Moderate

**Types of changes:**
New feature added to code base. 
Some modifications from the Matlab version of this feature
are that smoothing only occurs if the gaussian_std is greater than 
the bin dt (otherwise smoothing has no effect). Depending on 
the get_counts() function uses, smoothing option may be set in the
input parameters as well as only occurring when it will make a difference.
The indices of intervals with decoded sequences are returned along with
those start/stop times. This will likely not be useful once more classes 
are introduced into the code base. Might want to also consider using a 
low band pass filter (seems like there are many false-positives that even a 
small filter could correct).
