### PR TITLE
Epoch class and co-occurrence nan for neurons from the same tetrode

### DIFF
--- a/tests/test_co_occurrence.py
+++ b/tests/test_co_occurrence.py
@@ -23,8 +23,15 @@ def test_compute_cooccur():
                              [1., 0., 2.],
                              [0., 2., 0.]])
 
-    prob_active, prob_expected, prob_observed, prob_zscore = vdm.compute_cooccur(count_matrix, num_shuffles=100)
+    tetrode_mask = np.array([[True, True, False, False],
+                             [True, True, False, False],
+                             [False, False, True, False],
+                             [False, False, False, True]])
 
-    assert np.allclose(prob_active, np.array([1., 0., 2. / 3., 1. / 3.]))
-    assert np.allclose(prob_expected, np.array([0., 2. / 3., 0., 1. / 3., 0., (2. / 3. * 1. / 3.)]))
-    assert np.allclose(prob_observed, np.array([0., 2. / 3., 0., 1. / 3., 0., 0.]))
+    prob = vdm.compute_cooccur(count_matrix, tetrode_mask, num_shuffles=100)
+
+    assert np.allclose(prob['active'], np.array([1., 0., 2. / 3., 1. / 3.]))
+    assert np.isnan(prob['expected'][0])
+    assert np.allclose(prob['expected'][1:], np.array([2. / 3., 0., 1. / 3., 0., (2. / 3. * 1. / 3.)]))
+    assert np.isnan(prob['observed'][0])
+    assert np.allclose(prob['observed'][1:], np.array([2. / 3., 0., 1. / 3., 0., 0.]))

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -91,7 +91,7 @@ def test_epoch_too_many_parameters():
 
 def test_epoch_simple_intersect():
     times_1 = np.array([[0.0, 1.0],
-                        [0.9, 1.5],
+                        [1.1, 1.5],
                         [1.6, 2.0]])
     epoch_1 = vdm.Epoch(times_1)
 
@@ -105,17 +105,69 @@ def test_epoch_simple_intersect():
 
 def test_epoch_intersect():
     times_1 = np.array([[0.0, 1.0],
-                        [0.9, 1.5],
+                        [1.1, 1.5],
                         [1.6, 2.0]])
     epoch_1 = vdm.Epoch(times_1)
 
     times_2 = np.array([[1.2, 1.8]])
     epoch_2 = vdm.Epoch(times_2)
 
-    intersected_epochs = epoch_1.intersect(epoch_2)
+    intersects = epoch_1.intersect(epoch_2)
 
-    assert np.allclose(intersected_epochs.starts, np.array([1.2, 1.6]))
-    assert np.allclose(intersected_epochs.stops, np.array([1.5, 1.8]))
+    assert np.allclose(intersects.starts, np.array([1.2, 1.6]))
+    assert np.allclose(intersects.stops, np.array([1.5, 1.8]))
+
+
+def test_epoch_intersect_a_short():
+    times_a = np.array([[1.0, 2.0]])
+    epoch_a = vdm.Epoch(times_a)
+
+    times_b = np.array([[0.0, 3.0]])
+    epoch_b = vdm.Epoch(times_b)
+
+    intersects = epoch_a.intersect(epoch_b)
+
+    assert np.allclose(intersects.starts, np.array([1.0]))
+    assert np.allclose(intersects.stops, np.array([2.0]))
+
+
+def test_epoch_intersect_a_long():
+    times_a = np.array([[1.0, 2.0]])
+    epoch_a = vdm.Epoch(times_a)
+
+    times_b = np.array([[1.1, 1.9]])
+    epoch_b = vdm.Epoch(times_b)
+
+    intersects = epoch_a.intersect(epoch_b)
+
+    assert np.allclose(intersects.starts, np.array([1.1]))
+    assert np.allclose(intersects.stops, np.array([1.9]))
+
+
+def test_epoch_intersect_a_left():
+    times_a = np.array([[1.0, 2.0]])
+    epoch_a = vdm.Epoch(times_a)
+
+    times_b = np.array([[1.5, 2.5]])
+    epoch_b = vdm.Epoch(times_b)
+
+    intersects = epoch_a.intersect(epoch_b)
+
+    assert np.allclose(intersects.starts, np.array([1.5]))
+    assert np.allclose(intersects.stops, np.array([2.0]))
+
+
+def test_epoch_intersect_a_right():
+    times_a = np.array([[1.0, 2.0]])
+    epoch_a = vdm.Epoch(times_a)
+
+    times_b = np.array([[0.5, 1.7]])
+    epoch_b = vdm.Epoch(times_b)
+
+    intersects = epoch_a.intersect(epoch_b)
+
+    assert np.allclose(intersects.starts, np.array([1.0]))
+    assert np.allclose(intersects.stops, np.array([1.7]))
 
 
 def test_epoch_no_intersect():
@@ -157,49 +209,61 @@ def test_epoch_merge_with_gap():
     assert np.allclose(merged.stops, np.array([2.0]))
 
 
-def test_epoch_resize_both():
+def test_epoch_merge_far_stop():
+    times = np.array([[0.0, 10.0],
+                      [1.0, 3.0],
+                      [2.0, 5.0],
+                      [11.0, 12.0]])
+
+    epoch = vdm.Epoch(times)
+    merged = epoch.merge()
+    assert np.allclose(merged.starts, np.array([0.0, 10.0]))
+    assert np.allclose(merged.stops, np.array([11.0, 12.0]))
+
+
+def test_epoch_expand_both():
     times = np.array([[0.0, 1.0],
                       [0.9, 1.5],
                       [1.6, 2.0]])
     epoch = vdm.Epoch(times)
 
-    resized = epoch.resize(0.5)
+    resized = epoch.expand(0.5)
 
     assert np.allclose(resized.starts, np.array([-0.5, 0.4, 1.1]))
     assert np.allclose(resized.stops, np.array([1.5, 2.0, 2.5]))
 
 
-def test_epoch_resize_start():
+def test_epoch_expand_start():
     times = np.array([[0.0, 1.0],
                       [0.9, 1.5],
                       [1.6, 2.0]])
     epoch = vdm.Epoch(times)
 
-    resized = epoch.resize(0.5, direction='start')
+    resized = epoch.expand(0.5, direction='start')
 
     assert np.allclose(resized.starts, np.array([-0.5, 0.4, 1.1]))
     assert np.allclose(resized.stops, np.array([1.0, 1.5, 2.0]))
 
 
-def test_epoch_resize_stop():
+def test_epoch_expand_stop():
     times = np.array([[0.0, 1.0],
                       [0.9, 1.5],
                       [1.6, 2.0]])
     epoch = vdm.Epoch(times)
 
-    resized = epoch.resize(0.5, direction='stop')
+    resized = epoch.expand(0.5, direction='stop')
 
     assert np.allclose(resized.starts, np.array([0.0, 0.9, 1.6]))
     assert np.allclose(resized.stops, np.array([1.5, 2.0, 2.5]))
 
 
-def test_epoch_resize_shrink():
+def test_epoch_shrink():
     times = np.array([[0.0, 1.0],
                       [0.9, 1.5],
                       [1.6, 2.0]])
     epoch = vdm.Epoch(times)
 
-    shrinked = epoch.resize(-0.1)
+    shrinked = epoch.shrink(0.1)
 
     assert np.allclose(shrinked.starts, np.array([0.1, 1.0, 1.7]))
     assert np.allclose(shrinked.stops, np.array([0.9, 1.4, 1.9]))

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -1,5 +1,5 @@
 import numpy as np
-
+import pytest
 import vdmlab as vdm
 
 
@@ -29,3 +29,192 @@ def test_time_slice():
                                                        37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48,
                                                        49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60]))
     assert np.allclose(sliced_spikes_c.time, np.array([]))
+
+
+def test_epoch_duration():
+    times = np.array([[0.0, 1.0],
+                      [0.9, 1.5],
+                      [1.6, 2.0]])
+    epoch = vdm.Epoch(times)
+    assert np.allclose(epoch.durations, np.array([1., 0.6, 0.4]))
+
+
+def test_epoch_stops():
+    start_times = np.array([[0.0],
+                            [0.9],
+                            [1.6]])
+    durations = np.array([1., 0.6, 0.4])
+    epoch = vdm.Epoch(start_times, durations)
+    assert np.allclose(epoch.stops, np.array([1., 1.5, 2.]))
+
+
+def test_epoch_sort():
+    times = np.array([[1.6, 2.0],
+                      [0.0, 1.0],
+                      [0.9, 1.5]])
+    epoch = vdm.Epoch(times)
+    assert np.allclose(epoch.starts, np.array([0., 0.9, 1.6]))
+    assert np.allclose(epoch.stops, np.array([1., 1.5, 2.]))
+
+
+def test_epoch_sortlist():
+    start_times = [0.9, 0.0, 1.6]
+    durations = [0.6, 1.0, 0.4]
+    epoch = vdm.Epoch(start_times, durations)
+    assert np.allclose(epoch.starts, np.array([0.0, 0.9, 1.6]))
+    assert np.allclose(epoch.stops, np.array([1., 1.5, 2.]))
+
+
+def test_epoch_reshape():
+    times = np.array([[0.0, 0.9, 1.6], [1.0, 1.5, 2.0]])
+    epoch = vdm.Epoch(times)
+    assert np.allclose(epoch.time.shape, (3, 2))
+
+
+def test_epoch_centers():
+    times = np.array([[0.0, 1.0],
+                      [0.9, 1.4],
+                      [1.6, 2.0]])
+    epoch = vdm.Epoch(times)
+    assert np.allclose(epoch.centers, np.array([0.5, 1.15, 1.8]))
+
+
+def test_epoch_too_many_parameters():
+    times = np.array([[0.0, 1.0],
+                      [0.9, 1.5],
+                      [1.6, 2.0]])
+    durations = np.array([1., 0.6, 0.4])
+    with pytest.raises(ValueError) as excinfo:
+        epoch = vdm.Epoch(times, durations)
+    assert str(excinfo.value) == 'duration not allowed when using start and stop times'
+
+
+def test_epoch_simple_intersect():
+    times_1 = np.array([[0.0, 1.0],
+                        [0.9, 1.5],
+                        [1.6, 2.0]])
+    epoch_1 = vdm.Epoch(times_1)
+
+    times_2 = np.array([[1.55, 1.8]])
+    epoch_2 = vdm.Epoch(times_2)
+
+    intersected_epochs = epoch_1.intersect(epoch_2)
+    assert np.allclose(intersected_epochs.starts, np.array([1.6]))
+    assert np.allclose(intersected_epochs.stops, np.array([1.8]))
+
+
+def test_epoch_intersect():
+    times_1 = np.array([[0.0, 1.0],
+                        [0.9, 1.5],
+                        [1.6, 2.0]])
+    epoch_1 = vdm.Epoch(times_1)
+
+    times_2 = np.array([[1.2, 1.8]])
+    epoch_2 = vdm.Epoch(times_2)
+
+    intersected_epochs = epoch_1.intersect(epoch_2)
+
+    assert np.allclose(intersected_epochs.starts, np.array([1.2, 1.6]))
+    assert np.allclose(intersected_epochs.stops, np.array([1.5, 1.8]))
+
+
+def test_epoch_no_intersect():
+    times_1 = np.array([[0.0, 1.0],
+                        [0.9, 1.5],
+                        [1.6, 2.0]])
+    epoch_1 = vdm.Epoch(times_1)
+
+    times_2 = np.array([[1.5, 1.6]])
+    epoch_2 = vdm.Epoch(times_2)
+
+    intersected_epochs = epoch_1.intersect(epoch_2)
+
+    assert np.allclose(intersected_epochs.starts, np.array([]))
+    assert np.allclose(intersected_epochs.stops, np.array([]))
+
+
+def test_epoch_merge():
+    times = np.array([[0.0, 1.0],
+                      [0.9, 1.5],
+                      [1.6, 2.0]])
+
+    epoch = vdm.Epoch(times)
+
+    merged = epoch.merge()
+    assert np.allclose(merged.starts, np.array([0., 1.5]))
+    assert np.allclose(merged.stops, np.array([1.6, 2.0]))
+
+
+def test_epoch_merge_with_gap():
+    times = np.array([[0.0, 1.0],
+                      [0.9, 1.5],
+                      [1.6, 2.0]])
+
+    epoch = vdm.Epoch(times)
+
+    merged = epoch.merge(gap=0.1)
+    assert np.allclose(merged.starts, np.array([0.]))
+    assert np.allclose(merged.stops, np.array([2.0]))
+
+
+def test_epoch_resize_both():
+    times = np.array([[0.0, 1.0],
+                      [0.9, 1.5],
+                      [1.6, 2.0]])
+    epoch = vdm.Epoch(times)
+
+    resized = epoch.resize(0.5)
+
+    assert np.allclose(resized.starts, np.array([-0.5, 0.4, 1.1]))
+    assert np.allclose(resized.stops, np.array([1.5, 2.0, 2.5]))
+
+
+def test_epoch_resize_start():
+    times = np.array([[0.0, 1.0],
+                      [0.9, 1.5],
+                      [1.6, 2.0]])
+    epoch = vdm.Epoch(times)
+
+    resized = epoch.resize(0.5, direction='start')
+
+    assert np.allclose(resized.starts, np.array([-0.5, 0.4, 1.1]))
+    assert np.allclose(resized.stops, np.array([1.0, 1.5, 2.0]))
+
+
+def test_epoch_resize_stop():
+    times = np.array([[0.0, 1.0],
+                      [0.9, 1.5],
+                      [1.6, 2.0]])
+    epoch = vdm.Epoch(times)
+
+    resized = epoch.resize(0.5, direction='stop')
+
+    assert np.allclose(resized.starts, np.array([0.0, 0.9, 1.6]))
+    assert np.allclose(resized.stops, np.array([1.5, 2.0, 2.5]))
+
+
+def test_epoch_resize_shrink():
+    times = np.array([[0.0, 1.0],
+                      [0.9, 1.5],
+                      [1.6, 2.0]])
+    epoch = vdm.Epoch(times)
+
+    shrinked = epoch.resize(-0.1)
+
+    assert np.allclose(shrinked.starts, np.array([0.1, 1.0, 1.7]))
+    assert np.allclose(shrinked.stops, np.array([0.9, 1.4, 1.9]))
+
+
+def test_epoch_join():
+    times_1 = np.array([[0.0, 1.0],
+                        [0.9, 1.5],
+                        [1.6, 2.0]])
+    epoch_1 = vdm.Epoch(times_1)
+
+    times_2 = np.array([[1.8, 2.5]])
+    epoch_2 = vdm.Epoch(times_2)
+
+    union = epoch_1.join(epoch_2)
+
+    assert np.allclose(union.starts, np.array([0.0, 0.9, 1.6, 1.8]))
+    assert np.allclose(union.stops, np.array([1.0, 1.5, 2.0, 2.5]))

--- a/vdmlab/__init__.py
+++ b/vdmlab/__init__.py
@@ -1,4 +1,4 @@
-from .co_occurrence import spike_counts, compute_cooccur
+from .co_occurrence import spike_counts, get_tetrode_mask, compute_cooccur
 from .decoding import bayesian_prob, decode_location, filter_jumps
 from .lfp_filtering import detect_swr_hilbert
 from .maze_breakdown import expand_line, save_spike_position

--- a/vdmlab/__init__.py
+++ b/vdmlab/__init__.py
@@ -3,6 +3,7 @@ from .decoding import bayesian_prob, decode_location, filter_jumps
 from .lfp_filtering import detect_swr_hilbert
 from .maze_breakdown import expand_line, save_spike_position
 from .objects import (AnalogSignal,
+                      Epoch,
                       LocalFieldPotential,
                       Position,
                       SpikeTrain)


### PR DESCRIPTION
**Description:** 
Adding Epoch class (along with tests). Adding feature to co-occurrence 
such that probabilities from neurons from the same tetrode are excluded.

<!--- **Motivation and context:** -->

<!--- **Interactions with other PRs:** -->

**How has this been tested?** 
New Epoch tests. Not yet implemented in project code.
Co-occurrence ran with simple tests and in shortcut
project.

<!--- **Where should a reviewer start? -->

**How long should this take to review?**
Moderate

**Types of changes:**
New features. New object to replace dictionaries with 
start, stop keys and numpy arrays or lists that need to 
be in a given order for them to work (eg. phase times 
in the shortcut analysis).
