### PR TITLE
Loading .t files as uint32

### DIFF
--- a/nept/loaders_mclust.py
+++ b/nept/loaders_mclust.py
@@ -55,7 +55,12 @@ def load_mclust_t(filename):
     header = file_contents[header_begin_idx:header_end_idx]
 
     data = file_contents[header_end_idx:]
-    spike_times = np.fromstring(data, dtype=np.dtype('>Q'))
+    spike_times = np.fromstring(data, dtype=np.dtype('>L'))
+
+    # Since some .t files are in uint32 and others are in uint64,
+    # we can load all as uint32 (L) but have to remove all the 0's
+    # that result from interpreting a uint64 as a uint32.
+    spike_times = spike_times[spike_times > 0]
 
     # Spikes times are in timestamps (tenths of ms).
     # Let's convert the timestamps to seconds.


### PR DESCRIPTION
************
Description:
************
Loading .t files as uint32 (for both file types that were encoded with uint32 and uint64).

**Motivation and context:**
I tried to load R016 .t files for the tutorials, but they failed to load.
I found out this is because they were encoded as uint32,
whereas my shortcut .t files are uint64.
This fix should handle both cases by decoding the .t files as uint32 and removing all 0's,
which are generated when a uint64 is decoded as a uint32.
Probably we won't have a situation where uint64 is necessary 
(e.g. too many spike times for uint32 to handle).

<!--- **Interactions with other PRs:** -->

**How has this been tested?** 
Seems to load both types of .t files, no formal tests.

<!--- **Where should a reviewer start? -->

**How long should this take to review?**
Short

**Types of changes:**
Change to loader function.